### PR TITLE
Wait for each feat command to be completed before going on

### DIFF
--- a/ds001/FSL/SCRIPTS/level3.fsf
+++ b/ds001/FSL/SCRIPTS/level3.fsf
@@ -30,7 +30,7 @@ set fmri(featwatcher_yn) 1
 set fmri(sscleanup_yn) 0
 
 # Output directory
-set fmri(outputdir) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/LEVEL1"
+set fmri(outputdir) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/LEVEL2/group"
 
 # TR(s)
 set fmri(tr) 3

--- a/ds001/FSL/SCRIPTS/sub-01_run-01_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-01_run-01_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-01_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-01_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-01_run-02_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-01_run-02_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-01_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-01_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-01_run-03_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-01_run-03_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-01_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-01_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-02_run-01_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-02_run-01_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-02_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-02_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-02_run-02_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-02_run-02_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-02_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-02_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-02_run-03_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-02_run-03_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-02_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-02_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-03_run-01_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-03_run-01_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-03_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-03_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-03_run-02_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-03_run-02_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-03_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-03_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-03_run-03_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-03_run-03_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-03_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-03_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-04_run-01_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-04_run-01_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-04_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-04_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-04_run-02_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-04_run-02_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-04_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-04_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-04_run-03_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-04_run-03_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-04_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-04_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-05_run-01_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-05_run-01_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-05_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-05_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-05_run-02_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-05_run-02_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-05_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-05_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-05_run-03_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-05_run-03_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-05_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-05_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-06_run-01_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-06_run-01_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-06_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-06_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-06_run-02_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-06_run-02_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-06_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-06_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-06_run-03_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-06_run-03_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-06_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-06_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-07_run-01_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-07_run-01_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-07_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-07_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-07_run-02_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-07_run-02_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-07_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-07_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-07_run-03_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-07_run-03_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-07_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-07_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-08_run-01_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-08_run-01_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-08_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-08_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-08_run-02_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-08_run-02_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-08_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-08_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-08_run-03_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-08_run-03_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-08_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-08_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-09_run-01_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-09_run-01_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-09_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-09_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-09_run-02_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-09_run-02_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-09_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-09_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-09_run-03_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-09_run-03_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-09_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-09_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-10_run-01_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-10_run-01_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-10_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-10_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-10_run-02_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-10_run-02_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-10_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-10_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-10_run-03_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-10_run-03_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-10_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-10_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-11_run-01_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-11_run-01_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-11_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-11_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-11_run-02_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-11_run-02_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-11_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-11_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-11_run-03_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-11_run-03_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-11_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-11_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-12_run-01_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-12_run-01_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-12_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-12_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-12_run-02_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-12_run-02_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-12_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-12_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-12_run-03_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-12_run-03_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-12_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-12_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-13_run-01_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-13_run-01_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-13_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-13_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-13_run-02_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-13_run-02_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-13_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-13_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-13_run-03_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-13_run-03_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-13_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-13_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-14_run-01_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-14_run-01_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-14_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-14_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-14_run-02_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-14_run-02_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-14_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-14_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-14_run-03_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-14_run-03_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-14_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-14_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-15_run-01_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-15_run-01_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-15_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-15_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-15_run-02_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-15_run-02_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-15_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-15_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-15_run-03_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-15_run-03_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-15_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-15_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-16_run-01_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-16_run-01_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-16_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-16_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-16_run-02_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-16_run-02_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-16_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-16_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/ds001/FSL/SCRIPTS/sub-16_run-03_level1.fsf
+++ b/ds001/FSL/SCRIPTS/sub-16_run-03_level1.fsf
@@ -273,7 +273,7 @@ set feat_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPA
 set fmri(confoundevs) 0
 
 # Subject's structural image for analysis 1
-set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-16_T1w.nii.gz"
+set highres_files(1) "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/ANATOMICAL/sub-16_T1w_brain.nii.gz"
 
 # EV 1 title
 set fmri(evtitle1) "pumps_fixed"

--- a/scripts/lib/create_onset_files.m
+++ b/scripts/lib/create_onset_files.m
@@ -69,7 +69,7 @@ function create_onset_files(study_dir, OnsetDir, CondNames, removed_TR_time)
                 if ~iscell(cond_names)
                     cond_name = cond_names;
                     FSL3colfile=fullfile(OnsetDir,sprintf('%s_%s',sub_run, cond_name));
-                    system(['BIDSto3col.sh -b ' removed_TR_time onsets_opt dur_opt ' ' event_file ' ' FSL3colfile]);                   
+                    system(['BIDSto3col.sh -b ' removed_TR_time ' ' onsets_opt dur_opt ' ' event_file ' ' FSL3colfile]);                   
                     ThreeCol{j}=fullfile(OnsetDir,sprintf('%s_%s.txt',sub_run,cond_name));
                     CondNamesOnly{j} = cond_name;
                 else
@@ -89,8 +89,8 @@ function create_onset_files(study_dir, OnsetDir, CondNames, removed_TR_time)
                         height_opt = [' -h ', height];
 
                         pmod_cond_name = cond_names{1+jj};
-
-                        system(['BIDSto3col.sh -b ' removed_TR_time onsets_opt height_opt dur_opt ' ' event_file ' ' strrep(base_cond_file,'.txt', '')]);
+                        removed_TR_time = num2str(removed_TR_time);
+                        system(['BIDSto3col.sh -b ' removed_TR_time ' ' onsets_opt height_opt dur_opt ' ' event_file ' ' strrep(base_cond_file,'.txt', '')]);
                         pmod_cond_file_auto = strrep(base_cond_file, '.txt', '_pmod.txt');
                         pmod_cond_file = strrep(pmod_cond_file_auto, [base_cond_name '_pmod'], pmod_cond_name);
                         movefile(pmod_cond_file_auto, pmod_cond_file);

--- a/scripts/lib/fsl_processing.py
+++ b/scripts/lib/fsl_processing.py
@@ -1,4 +1,6 @@
 import os
+import time
+import sys
 from subprocess import check_call
 import glob
 import re
@@ -90,6 +92,20 @@ def create_onset_files(study_dir, OnsetDir, conditions):
     return cond_files
 
 
+def wait_for_feat(report_file):
+    running = True
+    while running:
+        time.sleep(10)
+
+        with open(report_file, "r") as fp:
+            report_head = fp.read()
+            if "STILL RUNNING" not in report_head:
+                running = False
+            else:
+                print("."),
+                sys.stdout.flush()
+
+
 def run_run_level_analyses(preproc_dir, run_level_fsf, level1_dir, cond_files):
 
     scripts_dir = os.path.join(preproc_dir, os.pardir, 'SCRIPTS')
@@ -130,8 +146,12 @@ def run_run_level_analyses(preproc_dir, run_level_fsf, level1_dir, cond_files):
                 f.write(run_fsf)
 
             cmd = "feat " + run_fsf_file
-            print(cmd)  
+            print(cmd)
             check_call(cmd, shell=True)
+
+            report_file = os.path.join(
+                os.path.dirname(run_fsf_file), 'report.html')
+            wait_for_feat(report_file)
 
 # out_dir='/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/LEVEL1/sub-01/run-01'
 # fmri='/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/FUNCTIONAL/sub-01_task-balloonanalogrisktask_run-01_bold'
@@ -180,8 +200,12 @@ def run_subject_level_analyses(level1_dir, sub_level_fsf, level2_dir):
             f.write(sub_fsf)
 
         cmd = "feat " + sub_fsf_file
-        print(cmd) 
+        print(cmd)
         check_call(cmd, shell=True)
+
+        report_file = os.path.join(
+            os.path.dirname(sub_fsf_file), 'report.html')
+        wait_for_feat(report_file)
 
 # out_dir='/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/LEVEL1/sub-01/combined'
 # feat_1=/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/LEVEL1/sub-01/run-01.feat
@@ -217,9 +241,12 @@ def run_group_level_analysis(level1_dir, group_level_fsf, level2_dir,
     with open(group_fsf_file, "w") as f:
         f.write(sub_fsf)
 
-    cmd = "feat " + group_fsf_file 
+    cmd = "feat " + group_fsf_file
     print(cmd)
     check_call(cmd, shell=True)
+    report_file = os.path.join(
+        os.path.dirname(group_fsf_file), 'report.html')
+    wait_for_feat(report_file)
 
 # out_dir=/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/LEVEL2/group
 # feat_1=/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/LEVEL1/sub-01/combined.gfeat/cope1.feat

--- a/scripts/lib/fsl_processing.py
+++ b/scripts/lib/fsl_processing.py
@@ -219,7 +219,7 @@ def run_subject_level_analyses(level1_dir, sub_level_fsf, level2_dir):
 # feat_3=/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/LEVEL1/sub-01/run-03.feat
 
 
-def run_group_level_analysis(level1_dir, group_level_fsf, level2_dir,
+def run_group_level_analysis(level2_dir, group_level_fsf, level3_dir,
                              contrast_id):
 
     scripts_dir = os.path.join(level2_dir, os.pardir, 'SCRIPTS')
@@ -228,11 +228,11 @@ def run_group_level_analysis(level1_dir, group_level_fsf, level2_dir,
         os.mkdir(scripts_dir)
 
     values = dict()
-    values['out_dir'] = level2_dir
+    values['out_dir'] = level3_dir
 
     feat_dirs = glob.glob(
         os.path.join(
-            level1_dir, 'sub-*', "combined.gfeat",
+            level2_dir, 'sub-*', "combined.gfeat",
             "cope" + contrast_id + ".feat"))
 
     for i, feat_dir in enumerate(feat_dirs):

--- a/scripts/lib/fsl_processing.py
+++ b/scripts/lib/fsl_processing.py
@@ -159,9 +159,6 @@ def run_run_level_analyses(preproc_dir, run_level_fsf, level1_dir, cond_files):
             print(cmd)
             check_call(cmd, shell=True)
 
-            report_file = os.path.join(
-                os.path.dirname(run_fsf_file), 'report.html')
-            wait_for_feat(report_file)
 
 # out_dir='/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/LEVEL1/sub-01/run-01'
 # fmri='/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/PREPROCESSING/FUNCTIONAL/sub-01_task-balloonanalogrisktask_run-01_bold'
@@ -200,6 +197,9 @@ def run_subject_level_analyses(level1_dir, sub_level_fsf, level2_dir):
         print(feat_dirs)
         for i, feat_dir in enumerate(feat_dirs):
             values['feat_' + str(i+1)] = feat_dir
+	    report_file = os.path.join(
+		feat_dir, 'report.html')
+	    wait_for_feat(report_file)
         with open(sub_level_fsf) as f:
             tpm = f.read()
             t = string.Template(tpm)
@@ -212,10 +212,6 @@ def run_subject_level_analyses(level1_dir, sub_level_fsf, level2_dir):
         cmd = "feat " + sub_fsf_file
         print(cmd)
         check_call(cmd, shell=True)
-
-        report_file = os.path.join(
-            os.path.dirname(sub_fsf_file), 'report.html')
-        wait_for_feat(report_file)
 
 # out_dir='/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/LEVEL1/sub-01/combined'
 # feat_1=/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/LEVEL1/sub-01/run-01.feat
@@ -241,6 +237,9 @@ def run_group_level_analysis(level1_dir, group_level_fsf, level2_dir,
 
     for i, feat_dir in enumerate(feat_dirs):
         values['feat_' + str(i+1)] = feat_dir
+	report_file = os.path.join(
+	    feat_dir, 'report.html')
+	wait_for_feat(report_file) 
 
     with open(group_level_fsf) as f:
         tpm = f.read()
@@ -254,9 +253,6 @@ def run_group_level_analysis(level1_dir, group_level_fsf, level2_dir,
     cmd = "feat " + group_fsf_file
     print(cmd)
     check_call(cmd, shell=True)
-    report_file = os.path.join(
-        os.path.dirname(group_fsf_file), 'report.html')
-    wait_for_feat(report_file)
 
 # out_dir=/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/LEVEL2/group
 # feat_1=/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/FSL/LEVEL1/sub-01/combined.gfeat/cope1.feat

--- a/scripts/lib/fsl_processing.py
+++ b/scripts/lib/fsl_processing.py
@@ -101,6 +101,8 @@ def wait_for_feat(report_file):
             report_head = fp.read()
             if "STILL RUNNING" not in report_head:
                 running = False
+                # Add a new line after all the dots
+                print(" ")
             else:
                 print("."),
                 sys.stdout.flush()

--- a/scripts/process_ds001.m
+++ b/scripts/process_ds001.m
@@ -20,7 +20,7 @@ if ~exist('copy_gunzip', 'file')
     addpath(fullfile(fileparts(mfilename('fullpath')), 'lib'))
 end
 
-copy_gunzip(study_dir, preproc_dir);
+% copy_gunzip(study_dir, preproc_dir);
 
 % Directory to store the onset files
 onsetDir = fullfile(results_dir,'ds001','SPM','ONSETS');

--- a/scripts/process_ds001_FSL.py
+++ b/scripts/process_ds001_FSL.py
@@ -15,11 +15,11 @@ if not os.path.isdir(fsl_dir):
 preproc_dir = os.path.join(fsl_dir, 'PREPROCESSING')
 level1_dir = os.path.join(fsl_dir, 'LEVEL1')
 level2_dir = os.path.join(fsl_dir, 'LEVEL1')
-level3_dir = os.path.join(fsl_dir, 'LEVEL3', 'group')
+level3_dir = os.path.join(fsl_dir, 'LEVEL2', 'group')
 
 cwd = os.path.dirname(os.path.realpath(__file__))
 
-copy_and_BET(raw_dir, preproc_dir)
+# copy_and_BET(raw_dir, preproc_dir)
 
 # Directory to store the onset files
 onsetDir = os.path.join(fsl_dir, 'ONSETS')
@@ -41,11 +41,11 @@ run_level_fsf = os.path.join(cwd, 'lib', 'template_ds001_FSL_level1.fsf')
 sub_level_fsf = os.path.join(cwd, 'lib', 'template_ds001_FSL_level2.fsf')
 grp_level_fsf = os.path.join(cwd, 'lib', 'template_ds001_FSL_level3.fsf')
 
-run_run_level_analyses(preproc_dir, run_level_fsf, level1_dir, cond_files)
+# run_run_level_analyses(preproc_dir, run_level_fsf, level1_dir, cond_files)
 
-run_subject_level_analyses(level1_dir, sub_level_fsf, level2_dir)
+# run_subject_level_analyses(level1_dir, sub_level_fsf, level2_dir)
 
-run_group_level_analysis(level1_dir, grp_level_fsf, level3_dir, '1')
+run_group_level_analysis(level2_dir, grp_level_fsf, level3_dir, '1')
 
 # run_group_level_analysis(raw_dir, level1_dir, 'template_ds001_SPM_level2', level2_dir);
 # %'/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/SOFTWARE_COMPARISON/ds001/SPM/LEVEL2/pumps_demean_vs_ctrl_demean'

--- a/scripts/process_ds001_oldtest.m
+++ b/scripts/process_ds001_oldtest.m
@@ -1,0 +1,40 @@
+base_dir = '/home/maullz/NIDM-Ex/BIDS_Data';
+
+raw_dir = fullfile(base_dir, 'DATA', 'BIDS');
+results_dir = fullfile(base_dir, 'RESULTS', 'SOFTWARE_COMPARISON');
+
+study_dir = fullfile(raw_dir, 'ds001_R2.0.4');
+spm_dir = fullfile(results_dir, 'ds001_oldtest', 'SPM');
+preproc_dir = fullfile(spm_dir, 'PREPROCESSING');
+level1_dir = fullfile(spm_dir, 'LEVEL1');
+level2_dir = fullfile(spm_dir, 'LEVEL2');
+
+% Add 'lib' folder to the matlab path
+if ~exist('copy_gunzip', 'file')
+    addpath(fullfile(fileparts(mfilename('fullpath')), 'lib'))
+end
+
+% copy_gunzip(study_dir, preproc_dir);
+
+% Directory to store the onset files
+onsetDir = fullfile(spm_dir,'ONSETS');
+
+% Define conditions and parametric modulations (if any)
+% FORMAT
+%   {VariableLabel,{TrialType,Durations}}
+%   {{VariableLabel,VariableModLabel},{TrialType,Duration,Amplitude}}
+%  
+CondNames = {...
+    {{'pumps_fixed','pumps_demean'}, {'pumps_demean', 0, 'pumps_demean'}},...
+    {'pumps_RT', {'pumps_demean', 'response_time'}},...
+    {{'cash_fixed','cash_demean'}, {'cash_demean', 0, 'cash_demean'}},...
+    {'cash_RT', {'cash_demean', 'response_time'}},...
+    {{'explode_fixed','explode_demean'}, {'explode_demean', 0, 'explode_demean'}},...
+    {{'control_pumps_fixed','control_pumps_demean'}, {'control_pumps_demean', 0, 'control_pumps_demean'}},...
+    {'control_pumps_RT', {'control_pumps_demean', 'response_time'}}};
+
+% create_onset_files(study_dir, onsetDir, CondNames);
+spm('defaults','FMRI');
+run_subject_level_analyses(study_dir, preproc_dir, 'template_ds001_SPM_level1', level1_dir);
+
+run_group_level_analysis(level1_dir, 'template_ds001_SPM_level2', level2_dir, '0001');


### PR DESCRIPTION
Hi @AlexBowring,

This pull request updates the FSL "master" script to wait for the analysis to be complete after each `feat` command is run. This should solve the issue of the subject-level analyses being run before the run-level analyses are done. 

Can you test this and merge if it works as expected?