### PR TITLE
Fixed error in comments, referring to incorrect Neurovault repo

### DIFF
--- a/figures/ds001_notebook.ipynb
+++ b/figures/ds001_notebook.ipynb
@@ -41,7 +41,7 @@
    "source": [
     "### Download the NIDM-Results packs from NeuroVault\n",
     "\n",
-    " - Query NeuroVault's API to retreive all NIDM packs in collection 2071\n",
+    " - Query NeuroVault's API to retreive all NIDM packs in collection 2209\n",
     " - Download and save the packs in sub-folder `input/ds001` "
    ]
   },


### PR DESCRIPTION
Caught small typo... ds001's notebooks' comment refers to Neurovault repo 2071, when it is actually 2209.  (If 2071 is really, truly out of date and not used, can it be removed?).

(I checked the other notebooks, and they don't have this problem.)