### PR TITLE
Use FSL perm mask for both FSL and FSL perm

### DIFF
--- a/figures/lib/dice.py
+++ b/figures/lib/dice.py
@@ -302,9 +302,11 @@ def dice(afni_exc_set_file, spm_exc_set_file,
     if spm_exc_set_file_neg is not None:
         spm_exc_set_file_neg = mask_using_nan(spm_exc_set_file_neg, spm_perm)
     if fsl_exc_set_file is not None:
-        fsl_exc_set_file = mask_using_nan(fsl_exc_set_file, fsl_stat_file)
+        fsl_exc_set_file = mask_using_nan(fsl_exc_set_file, fsl_perm)
     if fsl_exc_set_file_neg is not None:
-        fsl_exc_set_file_neg = mask_using_nan(fsl_exc_set_file_neg, fsl_stat_file)
+        # We mask fsl exc set with fsl perm stat because we know FEAT and 
+        # randomise use the same mask
+        fsl_exc_set_file_neg = mask_using_nan(fsl_exc_set_file_neg, fsl_perm)
     if fsl_perm_neg_exc is not None:
         fsl_perm_neg_exc = mask_using_nan(fsl_perm_neg_exc, fsl_perm)
     if fsl_perm_pos_exc is not None:


### PR DESCRIPTION
This follows a bug identified by @nicholst. randomise uses the mask produced by FEAT so FSL and FSL perm have the same background. The difference we had is due to the fact that we look for zeros to identify background voxels.

In this fix we determine the background using FSL perm statistic for both FSL and FSL permn excursion sets. 

@AlexBowring: this is ready to merge but will require rerunning the notebooks to get the latest version of the figures.